### PR TITLE
Setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,5 @@ build
 CMakeCache.txt
 cmake-build-debug/
 CMakeFiles/
-CGL184/
+CGL/
 Makefile

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,9 +121,9 @@ if(NOT WIN32)
     find_package(Freetype REQUIRED)
 endif()
 
-# CGL184
-add_subdirectory(CGL184)
-include_directories(CGL184/include)
+# CGL
+add_subdirectory(CGL)
+include_directories(CGL/include)
 
 #-------------------------------------------------------------------------------
 # Add subdirectories

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,14 @@ cmake_minimum_required(VERSION 2.8)
 # Application source
 set(APPLICATION_SOURCE
         main.cpp
-        hitable/TexturedDisk.cpp hitable/Disk.cpp hitable/Disk.h SchwarzschildBlackHoleEquation.h)
+        SchwarzschildBlackHoleEquation.h
+        utils.h
+        mappings/DiscMapping.h mappings/DiscMapping.cpp
+        mappings/SphericalMapping.h mappings/SphericalMapping.cpp
+        hitable/Disk.cpp hitable/Disk.h hitable/TexturedDisk.h
+        hitable/Horizon.h hitable/Horizon.cpp hitable/Sky.h hitable/Sky.cpp
+
+        hitable/TexturedDisk.cpp)
 
 # Eliot: not sure about this
 ## Windows-only sources

--- a/src/SchwarzschildBlackHoleEquation.h
+++ b/src/SchwarzschildBlackHoleEquation.h
@@ -1,26 +1,24 @@
-//
-// Created by Eliot Han on 4/28/19.
-//
-
 #ifndef BLACKHOLERAYTRACER_SCHWARZSCHILDBLACKHOLEEQUATION_H
 #define BLACKHOLERAYTRACER_SCHWARZSCHILDBLACKHOLEEQUATION_H
+
 
 #include "CGL/CGL.h"
 #include "CGL/vector3D.h"
 #include <vector>
 
-namespace CGL {
 
-  struct SchwarzschildBlackHoleEquation {
-    const float DefaultStepSize = 0.16f;
+using namespace CGL;
 
-    float h2;
-    float StepSize;
+struct SchwarzschildBlackHoleEquation {
+  const float DefaultStepSize = 0.16f;
 
-    /// Multiplier for the potential, ranging from 0 for no curvature, to -1.5 for full curvature.
-    float PotentialCoefficient;
+  float h2;
+  float StepSize;
 
-    // Used for Rk4 method
+  /// Multiplier for the potential, ranging from 0 for no curvature, to -1.5 for full curvature.
+  float PotentialCoefficient;
+
+  // Used for Rk4 method
 //    std::vector<double> *Y;
 //    std::vector<double> *F;
 //    std::vector<double> *K1;
@@ -28,39 +26,39 @@ namespace CGL {
 //    std::vector<double> *K3;
 //    std::vector<double> *K4;
 
-    SchwarzschildBlackHoleEquation(float potentialCoef) {
+  SchwarzschildBlackHoleEquation(float potentialCoef) {
 //          Y = new std::vector<double>();
 //          F = new std::vector<double>();
 //          K1 = new std::vector<double>();
 //          K2 = new std::vector<double>();
 //          K3 = new std::vector<double>();
 //          K4 = new std::vector<double>();
-          PotentialCoefficient = potentialCoef;
-          StepSize = DefaultStepSize;
-        }
+    PotentialCoefficient = potentialCoef;
+    StepSize = DefaultStepSize;
+  }
 
-    // Note: this function marked as unsafe in c# code
-    void SetInitialConditions(Vector3D& point, Vector3D& velocity) {
-      Vector3D c = cross(point, velocity);
-      h2 = c.norm2();
-    }
+  // Note: this function marked as unsafe in c# code
+  void SetInitialConditions(Vector3D& point, Vector3D& velocity) {
+    Vector3D c = cross(point, velocity);
+    h2 = c.norm2();
+  }
 
-    void Function(Vector3D& point, Vector3D& velocity)
-    {
-      Function(point, velocity, (point.norm() / 30.0) * StepSize);
-    }
+  void Function(Vector3D& point, Vector3D& velocity)
+  {
+    Function(point, velocity, (point.norm() / 30.0) * StepSize);
+  }
 
-   void Function(Vector3D& point,  Vector3D& velocity, float step) {
-     point += velocity * step;
+  void Function(Vector3D& point,  Vector3D& velocity, float step) {
+    point += velocity * step;
 
-     // this is the magical - 3/2 r^(-5) potential...
-     Vector3D accel = PotentialCoefficient * h2 * point / (float)pow(point.norm2(), 2.5);
-     velocity += accel * step;
+    // this is the magical - 3/2 r^(-5) potential...
+    Vector3D accel = PotentialCoefficient * h2 * point / (float)pow(point.norm2(), 2.5);
+    velocity += accel * step;
 
-     // C# project has commented out rk4 stuff here
-   }
+    // C# project has commented out rk4 stuff here
+  }
 
-  };
-}
+};
+
 
 #endif //BLACKHOLERAYTRACER_SCHWARZSCHILDBLACKHOLEEQUATION_H

--- a/src/SchwarzschildBlackHoleEquation.h
+++ b/src/SchwarzschildBlackHoleEquation.h
@@ -48,7 +48,7 @@ struct SchwarzschildBlackHoleEquation {
     Function(point, velocity, (point.norm() / 30.0) * StepSize);
   }
 
-  void Function(Vector3D& point,  Vector3D& velocity, float step) {
+  void Function(Vector3D& point, Vector3D& velocity, float step) {
     point += velocity * step;
 
     // this is the magical - 3/2 r^(-5) potential...

--- a/src/hitable/Disk.cpp
+++ b/src/hitable/Disk.cpp
@@ -1,0 +1,77 @@
+#include "Disk.h"
+#include "../SchwarzschildBlackHoleEquation.h"
+#include "../utils.h"
+#include "../mappings/SphericalMapping.h"
+
+#include <opencv2/opencv.hpp>
+#include <iostream>
+#include "CGL/CGL.h"
+#include <CGL/vector3D.h>
+#include "CGL/Color.h"
+
+
+using namespace CGL;
+using namespace std;
+using namespace CV;
+
+Disk::Disk(const double radiusInner1, const double radiusOuter1) {
+  radiusInner = radiusInner1;
+  radiusOuter = radiusOuter1;
+  radiusInnerSqr = radiusInner * radiusInner;
+  radiusOuterSqr = radiusOuter * radiusOuter;
+}
+
+Color Disk::GetColor(int side, double r, double theta, double phi) {
+  // white
+  return Color::White;
+}
+
+
+bool Disk::Hit(Vector3D &point, double sqrNorm, Vector3D &prevPoint, double prevSqrNorm,
+              Vector3D &velocity, SchwarzschildBlackHoleEquation equation, double r, double theta,
+              double phi, Color &color, bool stop, bool debug) {
+  // Remember what side of the plane we're currently on, so that we can detect
+  // whether we've crossed the plane after stepping.
+  int side = prevPoint.y > 0 ? -1 : prevPoint.y < 0 ? 1 : 0;
+
+  // Did we cross the horizontal plane?
+  bool success = false;
+  if (point.y * side >= 0) {
+    auto colpoint = IntersectionSearch(side, prevPoint, velocity, equation);
+    auto colpointsqr = colpoint.LengthSquared();
+
+    if ((colpointsqr >= radiusInnerSqr) && (colpointsqr <= radiusOuterSqr)) {
+      double tempR = 0, tempTheta = 0, tempPhi = 0;
+      Util.ToSpherical(colpoint.X, colpoint.Y, colpoint.Z, &tempR, &tempTheta, &tempPhi);
+
+      color = Util.addColor(GetColor(side, tempR, tempPhi, tempTheta + M_PI / 12), color);
+      stop = false;
+      success = true;
+    }
+  }
+  return success;
+}
+
+
+Vector3D Disk::IntersectionSearch(int side, Vector3D prevPoint, Vector3D velocity, SchwarzschildBlackHoleEquation equation) {
+  float stepLow = 0, stepHigh = equation.StepSize;
+  Vector3D newPoint = prevPoint;
+  Vector3D tempVelocity;
+  while (true) {
+    float stepMid = (stepLow + stepHigh) / 2;
+    newPoint = prevPoint;
+    tempVelocity = velocity;
+    equation.Function(&newPoint, &tempVelocity, stepMid);
+
+    if (abs(stepHigh - stepLow) < 0.00001) {
+      break;
+    }
+    if (side * newPoint.y > 0) {
+      stepHigh = stepMid;
+    }
+    else{
+      stepLow = stepMid;
+    }
+  }
+  return newPoint;
+}

--- a/src/hitable/Disk.cpp
+++ b/src/hitable/Disk.cpp
@@ -14,9 +14,9 @@ using namespace CGL;
 using namespace std;
 using namespace cv;
 
-Disk::Disk(const double radiusInner1, const double radiusOuter1) {
-  radiusInner = radiusInner1;
-  radiusOuter = radiusOuter1;
+Disk::Disk(const double radiusInner, const double radiusOuter) {
+  this->radiusInner = radiusInner;
+  this->radiusOuter = radiusOuter;
   radiusInnerSqr = radiusInner * radiusInner;
   radiusOuterSqr = radiusOuter * radiusOuter;
 }

--- a/src/hitable/Disk.cpp
+++ b/src/hitable/Disk.cpp
@@ -12,7 +12,7 @@
 
 using namespace CGL;
 using namespace std;
-using namespace CV;
+using namespace cv;
 
 Disk::Disk(const double radiusInner1, const double radiusOuter1) {
   radiusInner = radiusInner1;
@@ -37,14 +37,16 @@ bool Disk::Hit(Vector3D &point, double sqrNorm, Vector3D &prevPoint, double prev
   // Did we cross the horizontal plane?
   bool success = false;
   if (point.y * side >= 0) {
-    auto colpoint = IntersectionSearch(side, prevPoint, velocity, equation);
-    auto colpointsqr = colpoint.LengthSquared();
+    Vector3D colpoint = IntersectionSearch(side, prevPoint, velocity, equation);
+    double colpointsqr = colpoint.norm2();
 
     if ((colpointsqr >= radiusInnerSqr) && (colpointsqr <= radiusOuterSqr)) {
-      double tempR = 0, tempTheta = 0, tempPhi = 0;
-      Util.ToSpherical(colpoint.X, colpoint.Y, colpoint.Z, &tempR, &tempTheta, &tempPhi);
+      double tempR = 0;
+      double tempTheta = 0;
+      double tempPhi = 0;
+      Utils::ToSpherical(colpoint.x, colpoint.y, colpoint.z, tempR, tempTheta, tempPhi);
 
-      color = Util.addColor(GetColor(side, tempR, tempPhi, tempTheta + M_PI / 12), color);
+      color = Utils::AddColor(GetColor(side, tempR, tempPhi, tempTheta + M_PI / 12), color);
       stop = false;
       success = true;
     }
@@ -61,7 +63,7 @@ Vector3D Disk::IntersectionSearch(int side, Vector3D prevPoint, Vector3D velocit
     float stepMid = (stepLow + stepHigh) / 2;
     newPoint = prevPoint;
     tempVelocity = velocity;
-    equation.Function(&newPoint, &tempVelocity, stepMid);
+    equation.Function(newPoint, tempVelocity, stepMid);
 
     if (abs(stepHigh - stepLow) < 0.00001) {
       break;

--- a/src/hitable/Disk.h
+++ b/src/hitable/Disk.h
@@ -18,7 +18,7 @@ struct Disk {
     double radiusOuterSqr;
 
   public:
-    Disk(double radiusInner1, double radiusOuter1);
+    Disk(double radiusInner, double radiusOuter);
 
     bool Hit(Vector3D& point, double sqrNorm, Vector3D& prevPoint, double prevSqrNorm,
         Vector3D& velocity, SchwarzschildBlackHoleEquation equation, double r, double theta,

--- a/src/hitable/Disk.h
+++ b/src/hitable/Disk.h
@@ -18,14 +18,14 @@ struct Disk {
     double radiusOuterSqr;
 
   public:
-    Disk(const double radiusInner1, const double radiusOuter1);
+    Disk(double radiusInner1, double radiusOuter1);
 
     bool Hit(Vector3D& point, double sqrNorm, Vector3D& prevPoint, double prevSqrNorm,
         Vector3D& velocity, SchwarzschildBlackHoleEquation equation, double r, double theta,
         double phi, Color& color, bool stop, bool debug);
 
   protected:
-    Vector3D IntersectionSearch(Vector3D prevPoint, Vector3D velocity, SchwarzschildBlackHoleEquation equation);
+    Vector3D IntersectionSearch(int side, Vector3D prevPoint, Vector3D velocity, SchwarzschildBlackHoleEquation equation);
 
     CGL::Color GetColor(int side, double r, double theta, double phi);
 

--- a/src/hitable/Disk.h
+++ b/src/hitable/Disk.h
@@ -2,27 +2,33 @@
 #define BLACKHOLERAYTRACER_DISK_H
 
 #include "CGL/CGL.h"
+#include "../SchwarzschildBlackHoleEquation.h"
+#include <opencv2/opencv.hpp>
+#include <iostream>
 
+using namespace CGL;
+using namespace std;
+using namespace cv;
 
-namespace CGL {
-  struct Disk {
-     double radiusInner;
-     double radiusOuter;
-     double radiusInnerSqr;
-     double radiusOuterSqr;
+struct Disk {
+  private:
+    double radiusInner;
+    double radiusOuter;
+    double radiusInnerSqr;
+    double radiusOuterSqr;
 
-    Disk(const double radiusInner1, const double radiusOuter1) : {
-      radiusInner = radiusInner1;
-      radiusOuter = radiusOuter1;
-      radiusInnerSqr = radiusInner * radiusInner;
-      radiusOuterSqr = radiusOuter * radiusOuter;
-    }
+  public:
+    Disk(const double radiusInner1, const double radiusOuter1);
 
-    Spectrum
+    bool Hit(Vector3D& point, double sqrNorm, Vector3D& prevPoint, double prevSqrNorm,
+        Vector3D& velocity, SchwarzschildBlackHoleEquation equation, double r, double theta,
+        double phi, Color& color, bool stop, bool debug);
 
-  };
+  protected:
+    Vector3D IntersectionSearch(Vector3D prevPoint, Vector3D velocity, SchwarzschildBlackHoleEquation equation);
 
-}
+    CGL::Color GetColor(int side, double r, double theta, double phi);
 
+};
 
 #endif //BLACKHOLERAYTRACER_DISK_H

--- a/src/hitable/Horizon.cpp
+++ b/src/hitable/Horizon.cpp
@@ -1,0 +1,76 @@
+#include "Horizon.h"
+#include "../utils.h"
+#include "../mappings/SphericalMapping.h"
+#include "../SchwarzschildBlackHoleEquation.h"
+#include <opencv2/opencv.hpp>
+#include <iostream>
+#include "CGL/CGL.h"
+
+using namespace CGL;
+using namespace std;
+using namespace cv;
+
+Horizon::Horizon(Mat texture, bool checkered) : textureMap(texture.cols, texture.rows) {
+	this->checkered = checkered;
+	textureWidth = texture.cols;
+	textureBitmap = Utils::getNativeTextureBitmap(texture);
+}
+
+
+bool Horizon::Hit(Vector3D &point, double sqrNorm, Vector3D prevPoint,
+    double prevSqrNorm, Vector3D &velocity,
+    SchwarzschildBlackHoleEquation equation, double r, double theta,
+    double phi, Color &color, bool &stop, bool debug) {
+
+    // Has the ray fallen past the horizon?
+    if (prevSqrNorm > 1 && sqrNorm < 1) {
+        Vector3D colpoint = IntersectionSearch(prevPoint, velocity, equation);
+
+        double tempR = 0., tempTheta = 0., tempPhi = 0.;
+        Utils::ToSpherical(colpoint.x, colpoint.z, colpoint.y, tempR, tempTheta, tempPhi);
+
+        Color col = Color::Black;
+        if (checkered) {
+            double m1 = Utils::DoubleMod(tempTheta, 1.04719); // Pi / 3
+            double m2 = Utils::DoubleMod(tempPhi, 1.04719); // Pi / 3
+            if ((m1 < 0.52359) ^ (m2 < 0.52359)) { // Pi / 6
+                //col = Color.Green
+                col = Color(0., 1., 0.);
+            }
+        }
+        else if (!textureBitmap.empty()) {
+          int xPos, yPos;
+          textureMap.Map(r, theta, -phi, xPos, yPos);
+          col = Utils::getColorFromArgbHex(textureBitmap.at<char *>(yPos, xPos));
+        }
+        color = Utils::AddColor(col, color);
+        stop = true;
+        return true;
+    }
+    return false;
+}
+
+Vector3D Horizon::IntersectionSearch(Vector3D prevPoint, Vector3D velocity,
+                                     SchwarzschildBlackHoleEquation equation) {
+    float stepLow = 0, stepHigh = equation.StepSize;
+    Vector3D newPoint = prevPoint;
+    Vector3D tempVelocity;
+    while (true) {
+        float stepMid = (stepLow + stepHigh) / 2;
+        newPoint = prevPoint;
+        tempVelocity = velocity;
+        equation.Function(newPoint, tempVelocity, stepMid);
+
+        double distance = newPoint.norm2();
+        if (abs(stepHigh - stepLow) < 0.00001) {
+            break;
+        }
+        if (distance < radius) {
+            stepHigh = stepMid;
+        }
+        else {
+            stepLow = stepMid;
+        }
+    }
+    return newPoint;
+}

--- a/src/hitable/Horizon.h
+++ b/src/hitable/Horizon.h
@@ -1,0 +1,40 @@
+#ifndef HORIZON_H
+#define HORIZON_H
+
+#include "CGL/CGL.h"
+#include "../SchwarzschildBlackHoleEquation.h"
+#include "../mappings/SphericalMapping.h"
+#include <opencv2/opencv.hpp>
+#include <iostream>
+
+
+using namespace CGL;
+using namespace std;
+using namespace cv;
+
+struct Horizon {
+
+	private:
+		bool checkered;
+
+		SphericalMapping textureMap;
+		int textureWidth;
+		Mat textureBitmap;
+		double radius = 1.0;
+
+	public:
+		Horizon(Mat texture, bool checkered);
+
+		bool Hit(Vector3D &point, double sqrNorm, Vector3D prevPoint,
+				double prevSqrNorm, Vector3D &velocity,
+			SchwarzschildBlackHoleEquation equation, double r, double theta,
+			double phi, Color &color, bool &stop, bool debug);
+
+	protected:
+        Vector3D IntersectionSearch(Vector3D prevPoint, Vector3D velocity,
+            SchwarzschildBlackHoleEquation equation);
+
+};
+
+
+#endif /* HORIZON_H */

--- a/src/hitable/Horizon.h
+++ b/src/hitable/Horizon.h
@@ -24,15 +24,13 @@ struct Horizon {
 	public:
 		Horizon(Mat texture, bool checkered);
 
-		bool Hit(Vector3D &point, double sqrNorm, Vector3D prevPoint,
-				double prevSqrNorm, Vector3D &velocity,
+		bool Hit(Vector3D &point, double sqrNorm, Vector3D prevPoint, double prevSqrNorm, Vector3D &velocity,
 			SchwarzschildBlackHoleEquation equation, double r, double theta,
 			double phi, Color &color, bool &stop, bool debug);
 
 
 	protected:
-        Vector3D IntersectionSearch(Vector3D prevPoint, Vector3D velocity,
-            SchwarzschildBlackHoleEquation equation);
+        Vector3D IntersectionSearch(Vector3D prevPoint, Vector3D velocity, SchwarzschildBlackHoleEquation equation);
 
 };
 

--- a/src/hitable/Sky.cpp
+++ b/src/hitable/Sky.cpp
@@ -1,0 +1,62 @@
+#include <opencv2/opencv.hpp>
+#include <iostream>
+
+#include "CGL/CGL.h"
+#include "Sky.h"
+#include "../mappings/SphericalMapping.h"
+#include "../utils.h"
+
+using namespace CGL;
+using namespace std;
+using namespace cv;
+
+Sky::Sky(Mat texture, double radius) : textureMap(texture.cols, texture.rows) {
+    radius = radius;
+    radiusSqr = radius * radius;
+    if (!texture.empty()) {
+        textureWidth = texture.cols;
+        textureBitmap = Utils::getNativeTextureBitmap(texture);
+    }
+}
+
+Sky Sky::SetTextureOffset(double offset) {
+    textureOffset = offset;
+    return *this; // may need to change return type of function to Sky* instead
+}
+
+bool Sky::Hit(Vector3D &point, double sqrNorm, Vector3D prevPoint,
+    double prevSqrNorm, Vector3D &velocity, SchwarzschildBlackHoleEquation equation,
+    double r, double theta, double phi, Color &color, bool &stop, bool debug) {
+    if (sqrNorm > radiusSqr) {
+        int xPos, yPos;
+        textureMap.Map(r, theta, phi, xPos, yPos);
+        color = Utils::AddColor(Utils::getColorFromArgbHex(textureBitmap.at<char *>(yPos, xPos)), color);
+        stop = true;
+        return true;
+    }
+    return false;
+}
+
+Vector3D Sky::IntersectionSearch(Vector3D prevPoint, Vector3D velocity, SchwarzschildBlackHoleEquation equation) {
+    float stepLow = 0., stepHigh = equation.StepSize;
+    Vector3D newPoint = prevPoint;
+    Vector3D tempVelocity;
+    while (true) {
+        float stepMid = (stepLow + stepHigh) / 2.;
+        newPoint = prevPoint;
+        tempVelocity = velocity;
+        equation.Function(newPoint, tempVelocity, stepMid);
+
+        double distance = newPoint.norm2();
+        if (abs(stepHigh - stepLow) < 0.00001) {
+            break;
+        }
+        if (distance > radius) {
+            stepHigh = stepMid;
+        }
+        else {
+            stepLow = stepMid;
+        }
+    }
+    return newPoint;
+}

--- a/src/hitable/Sky.cpp
+++ b/src/hitable/Sky.cpp
@@ -11,7 +11,7 @@ using namespace std;
 using namespace cv;
 
 Sky::Sky(Mat texture, double radius) : textureMap(texture.cols, texture.rows) {
-    radius = radius;
+    this->radius = radius;
     radiusSqr = radius * radius;
     if (!texture.empty()) {
         textureWidth = texture.cols;

--- a/src/hitable/Sky.h
+++ b/src/hitable/Sky.h
@@ -1,0 +1,41 @@
+#ifndef SKY_H
+#define SKY_H
+
+#include <opencv2/opencv.hpp>
+#include <iostream>
+#include "../SchwarzschildBlackHoleEquation.h"
+#include "CGL/CGL.h"
+#include "../mappings/SphericalMapping.h"
+
+using namespace CGL;
+using namespace std;
+using namespace cv;
+
+
+// Struct definition + method signatures
+struct Sky {
+
+private:
+    SphericalMapping textureMap;
+    int textureWidth;
+    Mat textureBitmap;
+    double textureOffset = 0;
+    double radius;
+    double radiusSqr;
+
+public:
+    Sky(Mat texture, double radius);
+
+    Sky SetTextureOffset(double offset);
+
+    bool Hit(Vector3D &point, double sqrNorm, Vector3D prevPoint,
+        double prevSqrNorm, Vector3D &velocity, SchwarzschildBlackHoleEquation equation,
+        double r, double theta, double phi, Color &color, bool &stop, bool debug);
+
+protected:
+    Vector3D IntersectionSearch(Vector3D prevPoint, Vector3D velocity, SchwarzschildBlackHoleEquation equation);
+
+};
+
+
+#endif /* SKY_H */

--- a/src/hitable/TexturedDisk.cpp
+++ b/src/hitable/TexturedDisk.cpp
@@ -1,0 +1,20 @@
+#include "TexturedDisk.h"
+#include "CGL/CGL.h"
+#include "../SchwarzschildBlackHoleEquation.h"
+#include "../utils.h"
+#include "../mappings/DiscMapping.h"
+#include <opencv2/opencv.hpp>
+#include <iostream>
+
+TexturedDisk::TexturedDisk(double radiusInner, double radiusOuter, Mat texture)
+    : Disk(radiusInner, radiusOuter), textureMap(radiusInner, radiusOuter, texture.cols, texture.rows) {
+  textureWidth = texture.cols;
+  textureBitmap = Utils::getNativeTextureBitmap(texture);
+}
+
+Color TexturedDisk::GetColor(int side, double r, double theta, double phi) {
+  int xPos, yPos;
+  textureMap.Map(r, theta, phi, xPos, yPos);
+  return Utils::getColorFromArgbHex(textureBitmap.at<char *>(yPos, xPos)); // row major order so like this apparently. needs testing
+  // original code: return Color.FromArgb(textureBitmap[yPos * textureWidth + xPos]);
+}

--- a/src/hitable/TexturedDisk.h
+++ b/src/hitable/TexturedDisk.h
@@ -5,15 +5,13 @@
 #include "../SchwarzschildBlackHoleEquation.h"
 #include "Disk.h"
 #include "../utils.h"
-//#include "../mappings/DiscMapping.h"
+#include "../mappings/DiscMapping.h"
 #include <opencv2/opencv.hpp>
 #include <iostream>
 
 using namespace CGL;
 using namespace std;
 using namespace cv;
-
-// TODO: Util.getNativeTextureBitMap, DiscMapping
 
 struct TexturedDisk : Disk {
   private:
@@ -22,20 +20,10 @@ struct TexturedDisk : Disk {
     Mat textureBitmap;
 
 public:
-  TexturedDisk(double radiusInner, double radiusOuter, Mat texture)
-      : Disk(radiusInner, radiusOuter) {
-    textureMap = new DiscMapping(radiusInner, radiusOuter, texture.Width, texture.Height);
-    textureWidth = texture.cols;
-    textureBitmap = Util.getNativeTextureBitmap(texture);
-  }
+  TexturedDisk(double radiusInner, double radiusOuter, Mat texture);
 
 protected:
-  Color TexturedDisk::GetColor(int side, double r, double theta, double phi) {
-    int xPos, yPos;
-    textureMap.Map(r, theta, phi, &xPos, &yPos);
-    return Utils::getColorFromArgbHEX(textureBitmap.at(yPos, xPos)); // row major order so like this apparently. needs testing
-    // original code: return Color.FromArgb(textureBitmap[yPos * textureWidth + xPos]);
-  }
+  Color GetColor(int side, double r, double theta, double phi);
 };
 
 #endif //BLACKHOLERAYTRACER_TEXTUREDDISK_H

--- a/src/hitable/TexturedDisk.h
+++ b/src/hitable/TexturedDisk.h
@@ -1,0 +1,41 @@
+#ifndef BLACKHOLERAYTRACER_TEXTUREDDISK_H
+#define BLACKHOLERAYTRACER_TEXTUREDDISK_H
+
+#include "CGL/CGL.h"
+#include "../SchwarzschildBlackHoleEquation.h"
+#include "Disk.h"
+#include "../utils.h"
+//#include "../mappings/DiscMapping.h"
+#include <opencv2/opencv.hpp>
+#include <iostream>
+
+using namespace CGL;
+using namespace std;
+using namespace cv;
+
+// TODO: Util.getNativeTextureBitMap, DiscMapping
+
+struct TexturedDisk : Disk {
+  private:
+    DiscMapping textureMap;
+    int textureWidth;
+    Mat textureBitmap;
+
+public:
+  TexturedDisk(double radiusInner, double radiusOuter, Mat texture)
+      : Disk(radiusInner, radiusOuter) {
+    textureMap = new DiscMapping(radiusInner, radiusOuter, texture.Width, texture.Height);
+    textureWidth = texture.cols;
+    textureBitmap = Util.getNativeTextureBitmap(texture);
+  }
+
+protected:
+  Color TexturedDisk::GetColor(int side, double r, double theta, double phi) {
+    int xPos, yPos;
+    textureMap.Map(r, theta, phi, &xPos, &yPos);
+    return Utils::getColorFromArgbHEX(textureBitmap.at(yPos, xPos)); // row major order so like this apparently. needs testing
+    // original code: return Color.FromArgb(textureBitmap[yPos * textureWidth + xPos]);
+  }
+};
+
+#endif //BLACKHOLERAYTRACER_TEXTUREDDISK_H

--- a/src/mappings/DiscMapping.cpp
+++ b/src/mappings/DiscMapping.cpp
@@ -4,11 +4,11 @@
 #include "DiscMapping.h"
 #include "CGL/CGL.h"
 
-DiscMapping::DiscMapping(double rMin1, double rMax1, int sizeX1, int sizeY1) {
-  rMax = rMax1;
-  rMin = rMin1;
-  sizeX = sizeX1;
-  sizeY = sizeY1;
+DiscMapping::DiscMapping(double rMin, double rMax, int sizeX, int sizeY) {
+  this->rMax = rMax;
+  this->rMin = rMin;
+  this->sizeX = sizeX;
+  this->sizeY = sizeY;
 }
 
 void DiscMapping::Map(const double r, const double theta, const double phi, int &x, int &y) {

--- a/src/mappings/DiscMapping.cpp
+++ b/src/mappings/DiscMapping.cpp
@@ -1,0 +1,25 @@
+#include <iostream>
+#include <math.h>
+
+#include "DiscMapping.h"
+#include "CGL/CGL.h"
+
+DiscMapping::DiscMapping(double rMin1, double rMax1, int sizeX1, int sizeY1) {
+  rMax = rMax1;
+  rMin = rMin1;
+  sizeX = sizeX1;
+  sizeY = sizeY1;
+}
+
+void DiscMapping::Map(const double r, const double theta, const double phi, int &x, int &y) {
+  if (r < rMin || r > rMax)
+  {
+    x = 0;
+    y = sizeY;
+  }
+
+  x = (int)(phi / (2 * M_PI) * sizeX) % sizeX;
+  if (x < 0) { x = sizeX + x; }
+  y = (int)((r - rMin) / (rMax - rMin) * sizeY);
+  if (y > sizeY - 1) { y = sizeY - 1; }
+}

--- a/src/mappings/DiscMapping.h
+++ b/src/mappings/DiscMapping.h
@@ -16,7 +16,7 @@ struct DiscMapping {
     int sizeY;
 
   public:
-    DiscMapping(double rMin, double rMax, int sizeX1, int sizeY1);
+    DiscMapping(double rMin, double rMax, int sizeX, int sizeY);
 
     void Map(double r, double theta, double phi, int &x, int &y);
 };

--- a/src/mappings/DiscMapping.h
+++ b/src/mappings/DiscMapping.h
@@ -1,0 +1,24 @@
+#ifndef BLACKHOLERAYTRACER_DISCMAPPING_H
+#define BLACKHOLERAYTRACER_DISCMAPPING_H
+
+#include <iostream>
+
+#include "CGL/CGL.h"
+
+using namespace CGL;
+using namespace std;
+
+struct DiscMapping {
+  private:
+    double rMin;
+    double rMax;
+    int sizeX;
+    int sizeY;
+
+  public:
+    DiscMapping(double rMin, double rMax, int sizeX1, int sizeY1);
+
+    void Map(double r, double theta, double phi, int &x, int &y);
+};
+
+#endif //BLACKHOLERAYTRACER_DISCMAPPING_H

--- a/src/mappings/SphericalMapping.cpp
+++ b/src/mappings/SphericalMapping.cpp
@@ -1,0 +1,36 @@
+#include <iostream>
+#include <math.h>
+
+#include "SphericalMapping.h"
+#include "CGL/CGL.h"
+
+using namespace CGL;
+using namespace std;
+
+SphericalMapping::SphericalMapping(int sizex, int sizey) {
+    SizeX = sizex;
+    SizeY = sizey;
+}
+
+void SphericalMapping::Map(const double r, const double theta, const double phi, int &x, int &y) {
+    x = (int)((phi / (2. * M_PI)) * SizeX) % SizeX;
+    y = (int)((theta / M_PI) * SizeY) % SizeY;
+
+    if (x < 0) {
+        x = SizeX + x;
+    }
+    if (y < 0) {
+        y = SizeY + y;
+    }
+}
+
+void SphericalMapping::MapCartesian(const double x, const double y, const double z, int &u, int &v) {
+    u = (int)((0.5 + atan2(z, x) / (2. * M_PI)) * SizeX) % SizeX;
+    v = (int)((0.5 - (asin(y) / M_PI)) * SizeY) % SizeY;
+    if (u < 0) {
+        u = SizeX + u;
+    }
+    if (v < 0) {
+        v = SizeY + v;
+    }
+}

--- a/src/mappings/SphericalMapping.h
+++ b/src/mappings/SphericalMapping.h
@@ -1,0 +1,23 @@
+#ifndef SPHERICALMAPPING_H
+#define SPHERICALMAPPING_H
+
+#include <iostream>
+
+#include "CGL/CGL.h"
+
+using namespace CGL;
+using namespace std;
+
+struct SphericalMapping {
+    private:
+        int SizeX;
+        int SizeY;
+
+    public:
+        SphericalMapping(int sizex, int sizey);
+
+        void Map(double r, double theta, double phi, int &x, int &y);
+        void MapCartesian(double x, double y, double z, int &u, int &v);
+};
+
+#endif /* SPHERICALMAPPING_H */

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,0 +1,123 @@
+#ifndef UTILS_H
+#define UTILS_H
+
+#include <iostream>
+#include <opencv2/opencv.hpp>
+#include "CGL/CGL.h"
+#include "CGL/Color.h"
+#include "CGL/Vector3D.h"
+
+using namespace CGL;
+using namespace std;
+using namespace cv;
+
+namespace Utils {
+
+  static void ToCartesian(const double r, const double theta, const double phi, double &x, double &y, double &z) {
+    x = r * cos(phi) * sin(theta);
+    y = r * sin(phi) * sin(theta);
+    z = r * cos(theta);
+  }
+
+  static void ToSpherical(const double x, const double y, const double z, double &r, double &theta, double &phi) {
+    r = sqrt(x * x + y * y + z * z);
+    phi = atan2(y, x);
+    theta = acos(z / r);
+  }
+
+  static void ToSpherical(const Vector3D v, double &r, double &theta, double &phi) {
+    r = sqrt(v.x * v.x + v.y * v.y + v.z * v.z);
+    phi = atan2(v.y, v.x);
+    theta = acos(v.z / r);
+  }
+
+  static double DoubleMod(double n, double m) {
+    double x = floor(n / m);
+    return n - (m * x);
+  }
+
+  // Eliot: not sure about this one. let's see how it goes
+  static Mat getNativeTextureBitmap(Mat texture) {
+    return texture.clone();
+  }
+
+  // Used in Utils::AddColor()
+  // https://stackoverflow.com/questions/23215600/algorithm-of-bitmap-getbrightness-in-c-sharp
+  static float GetBrightness(Color c) {
+    float r = (float)c.r / 255.0f;
+    float g = (float)c.g / 255.0f;
+    float b = (float)c.b / 255.0f;
+
+    float max, min;
+
+    max = r; min = r;
+
+    if (g > max) max = g;
+    if (b > max) max = b;
+
+    if (g < min) min = g;
+    if (b < min) min = b;
+
+    return (max + min) / 2;
+  }
+
+
+// Based off CGL's color.cpp fromHex(). Only difference is to also zero out alpha value
+// Replace C# project's Color.FromArgb(Int32) with this
+  static Color getColorFromArgbHex(const char* s) {
+    // Ignore leading hashmark.
+    if( s[0] == '#' ) {
+      s++;
+    }
+
+    // Set stream formatting to hexadecimal.
+    stringstream ss;
+    ss << hex;
+
+    // Convert to integer.
+    unsigned int rgb;
+    ss << s;
+    ss >> rgb;
+
+    // Extract 8-byte chunks and normalize.
+    Color c;
+    c.r = (float)( ( rgb & 0x00FF0000 ) >> 16 ) / 255.0;
+    c.g = (float)( ( rgb & 0x0000FF00 ) >>  8 ) / 255.0;
+    c.b = (float)( ( rgb & 0x000000FF ) >>  0 ) / 255.0;
+
+    return c;
+  }
+
+  static int Cap(int x, int max) {
+    if (x > max) {
+      return max;
+    }
+    else {
+      return x;
+    }
+  }
+
+  static int CapMin(int x, int min) {
+    if (x < min) {
+      return min;
+    }
+    else {
+      return x;
+    }
+  }
+
+  static Color AddColor(Color hitColor, Color tintColor) {
+    // Assuming tintColor is not transparent
+    float brightness = GetBrightness(tintColor);
+    Color c;
+    c.r = Cap((int)(1. - brightness) * hitColor.r + CapMin(tintColor.r, 0) * 255. / 205., 255);
+    c.g = Cap((int)(1. - brightness) * hitColor.g + CapMin(tintColor.g, 0) * 255. / 205., 255);
+    c.b = Cap((int)(1. - brightness) * hitColor.b + CapMin(tintColor.b, 0) * 255. / 205., 255);
+    return c;
+  }
+
+}
+
+
+
+#endif /* UTILS_H */


### PR DESCRIPTION
note in particular:
 ```
Color.FromArgb(textureBitmap[yPos * textureWidth + xPos]) -> 
Utils::getColorFromArgbHex(textureBitmap.at<char *>(yPos, xPos))
```
```
if (textureBitmap != NULL) ->
if (!textureBitmap.empty())
```

Also, be careful with passing by value and pass by reference into functions. If a function definition is defined with ref parameters, replace them in c++ with &. However, unlike C#, when calling this function in c++, there is no need to put & in front of the reference parameter, it's done for you.
https://www.ibm.com/support/knowledgecenter/en/SSLTBW_2.3.0/com.ibm.zos.v2r3.cbclx01/cplr233.htm
for an example, look at how `equation.Function()` is called in any of the hitables implementation files.

I've modified some of the hitables' constructors to work in c++ using initialization lists.
https://stackoverflow.com/questions/2785612/c-what-does-the-colon-after-a-constructor-mean

I am not sure if Utils getNativeTextureBitmap() is right.